### PR TITLE
Bugfix

### DIFF
--- a/Affenbox/Affenbox.ino
+++ b/Affenbox/Affenbox.ino
@@ -2991,8 +2991,9 @@ void adminMenuAction()
 //////////////////////////////////////////////////////////////////////////
 void loop()
 {
-  checkStandbyAtMillis();
+  //19.8.22 Change order of mp3.loop and checkStanbyAtMillis to prevent unexpected shutdowns
   mp3.loop();
+  checkStandbyAtMillis();  
 
 #if defined FADING_LED
   fadeStatusLed(isPlaying());


### PR DESCRIPTION
Change order of mp3.loop and checkStanbyAtMillis in void loop() to prevent unexpected shutdowns